### PR TITLE
Add CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on:
     types: [created]
 jobs:
   regression_testing_job:
-    if: (github.event.comment.body == 'run') || startsWith(github.event.comment.body, 'run with checking out ') || startsWith(github.event.comment.body, 'run with pr ')
+    if: startsWith(github.event.comment.body, 'run')
     runs-on: ubuntu-latest
     name: a job for regression testing
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ package-lock.json
 !.yarn/sdks
 !.yarn/versions
 .pnp.*
+/workspace

--- a/cli.mjs
+++ b/cli.mjs
@@ -106,8 +106,6 @@ async function getDifference({
   await runGit("commit", ["-am", '"Format with original version."', "--allow-empty"], directory);
 
   await runPrettier(alternativePrettier, directory);
-  const f = path.join(directory, "selectpage.js");
-  await fs.writeFile(f, (await fs.readFile(f, "utf8")).replace(/a/g, "A"));
   const { stdout } = await runGit("diff", [], directory);
   return stdout;
 }

--- a/cli.mjs
+++ b/cli.mjs
@@ -1,0 +1,151 @@
+import fs from "fs/promises";
+import path from "path";
+import execa from "execa";
+
+const defaultOriginal = "prettier/prettier";
+const defaultTargets = [
+  "https://github.com/prettier/prettier",
+  "https://github.com/vuejs/eslint-plugin-vue",
+  "https://github.com/babel/babel",
+  "https://github.com/excalidraw/excalidraw",
+];
+
+const WORKSPACE = path.join(process.cwd(), "workspace");
+const fileExists = (file) =>
+  fs.stat(file).then(
+    () => true,
+    () => false
+  );
+
+function parseInput() {
+  const pieces = process.argv.slice(2);
+  const alternative = pieces[0];
+  const secondText = pieces[1] || "";
+
+  if (secondText.toLowerCase() !== "vs") {
+    pieces.splice(1, 0, "vs", "");
+  }
+
+  const original = pieces[2] || defaultOriginal;
+  let targets = [];
+
+  if (pieces.length > 4 && pieces[3].toLowerCase() === "on") {
+    targets = pieces.slice(4);
+  }
+
+  if (targets.length === 0) {
+    targets = defaultTargets;
+  }
+
+  return { original, alternative, targets };
+}
+
+function runYarn(command, yarnArgument, cwd) {
+  const subprocess = execa("yarn", [command, yarnArgument], { cwd });
+  subprocess.stdout.pipe(process.stdout);
+  return subprocess;
+}
+
+function runGit(command, gitArguments, cwd) {
+  return execa(
+    "git",
+    [command, ...(Array.isArray(gitArguments) ? gitArguments : [gitArguments])],
+    { cwd }
+  );
+}
+
+function runPrettier(prettier, cwd) {
+  const subprocess = execa(
+    "node",
+    [prettier, ".", "--ignore-unknown", "--write"],
+    { cwd }
+  );
+  subprocess.stdout.pipe(process.stdout);
+  return subprocess;
+}
+
+async function installPrettier(type, version) {
+  const directory = path.join(WORKSPACE, type);
+  await fs.mkdir(directory, { recursive: true });
+  await runYarn("init", "-y", directory);
+  await runYarn("add", `prettier@${version}`, directory);
+
+  for (const binFile of ["bin/prettier.js", "bin-prettier.js"]) {
+    const prettierPath = path.join(
+      directory,
+      `node_modules/prettier/${binFile}`
+    );
+
+    if (await fileExists(prettierPath)) {
+      return prettierPath;
+    }
+  }
+
+  throw new Error(`Can not find bin file on "prettier@${version}".`);
+}
+
+async function getDifference({
+  target,
+  originalPrettier,
+  alternativePrettier,
+}) {
+  const directory = path.join(
+    WORKSPACE,
+    target.split("/").filter(Boolean).pop()
+  );
+  if (!(await fileExists(directory)))
+    await runGit(
+      "clone",
+      [target, "--single-branch", "--depth", "1", directory],
+      WORKSPACE
+    );
+  await runPrettier(originalPrettier, directory);
+
+  const { exitCode } = await runGit(
+    "diff",
+    ["--name-only", "--exit-code"],
+    directory
+  );
+
+  // git diff --name-only --exit-code
+  if (exitCode !== 0) {
+    await runGit("commit", ["-am", "Format with original version."], directory);
+  }
+
+  await runPrettier(alternativePrettier, directory);
+  const f = path.join(directory, "selectpage.js");
+  await fs.writeFile(f, (await fs.readFile(f, "utf8")).replace(/a/g, "A"));
+  const { stdout } = await runGit("diff", [], directory);
+  return stdout;
+}
+
+const { original, alternative, targets } = parseInput();
+const originalPrettier = await installPrettier("original", original);
+const alternativePrettier = await installPrettier("alternative", alternative);
+
+const differences = [];
+for (const target of targets) {
+  differences.push({
+    target,
+    differences: await getDifference({
+      target,
+      originalPrettier,
+      alternativePrettier,
+    }),
+  });
+}
+
+const reportFile = path.join(WORKSPACE, "report.json");
+await fs.writeFile(
+  reportFile,
+  JSON.stringify(
+    {
+      original,
+      alternative,
+      targets,
+      differences,
+    },
+    undefined,
+    2
+  )
+);

--- a/cli.mjs
+++ b/cli.mjs
@@ -101,14 +101,14 @@ async function getDifference({
     );
   await runPrettier(originalPrettier, directory);
 
-  const { exitCode } = await runGit(
+  const { stdout: differencesOnOriginalPrettier } = await runGit(
     "diff",
-    ["--name-only", "--exit-code"],
+    ["--name-only"],
     directory
   );
 
   // git diff --name-only --exit-code
-  if (exitCode !== 0) {
+  if (differencesOnOriginalPrettier) {
     await runGit("commit", ["-am", "Format with original version."], directory);
   }
 

--- a/cli.mjs
+++ b/cli.mjs
@@ -101,16 +101,7 @@ async function getDifference({
     );
   await runPrettier(originalPrettier, directory);
 
-  const { stdout: differencesOnOriginalPrettier } = await runGit(
-    "diff",
-    ["--name-only"],
-    directory
-  );
-
-  // git diff --name-only --exit-code
-  if (differencesOnOriginalPrettier) {
-    await runGit("commit", ["-am", "Format with original version."], directory);
-  }
+  await runGit("commit", ["-am", "Format with original version.", "--allow-empty"], directory);
 
   await runPrettier(alternativePrettier, directory);
   const f = path.join(directory, "selectpage.js");

--- a/cli.mjs
+++ b/cli.mjs
@@ -57,7 +57,7 @@ function runGit(command, gitArguments, cwd) {
 function runPrettier(prettier, cwd) {
   const subprocess = execa(
     "node",
-    [prettier, ".", "--ignore-unknown", "--write"],
+    [prettier, "src/**/*.js", "--ignore-unknown", "--write"],
     { cwd }
   );
   subprocess.stdout.pipe(process.stdout);

--- a/cli.mjs
+++ b/cli.mjs
@@ -101,8 +101,8 @@ async function getDifference({
     );
   await runPrettier(originalPrettier, directory);
 
-  await runGit("config", ["--global", "user.email", "you@example.com"]);
-  await runGit("config", ["--global", "user.name", "Your Name"]);
+  await runGit("config", ["user.email", "you@example.com"], directory);
+  await runGit("config", ["user.name", "Your Name"], directory);
   await runGit("commit", ["-am", '"Format with original version."', "--allow-empty"], directory);
 
   await runPrettier(alternativePrettier, directory);

--- a/cli.mjs
+++ b/cli.mjs
@@ -101,7 +101,9 @@ async function getDifference({
     );
   await runPrettier(originalPrettier, directory);
 
-  await runGit("commit", ["-am", "Format with original version.", "--allow-empty"], directory);
+  await runGit("config", ["--global", "user.email", "you@example.com"]);
+  await runGit("config", ["--global", "user.name", "Your Name"]);
+  await runGit("commit", ["-am", '"Format with original version."', "--allow-empty"], directory);
 
   await runPrettier(alternativePrettier, directory);
   const f = path.join(directory, "selectpage.js");


### PR DESCRIPTION
Not done yet, the idea is support `run alternativeVersionPrettier vs originalVersionPrettier on project1 project2 ...  projectN` both local CLI and Github Actions.

`alternativeVersionPrettier` required, any prettier version `yarn` supports, like `2.0.0`, `fisker/prettier#ref` etc., will run `yarn add prettier@fisker/prettier#ref` to install

`originalVersionPrettier` default `prettier/prettier`, same as `alternativeVersionPrettier`.


The CLI will format any repo with `originalVersionPrettier`, then commit, run `alternativeVersionPrettier` to get the differences.



