### PR TITLE
Avoid to ignore errors

### DIFF
--- a/src/execute/run-prettier.ts
+++ b/src/execute/run-prettier.ts
@@ -38,6 +38,8 @@ export async function runPrettier(
         cwd: repositoryPath,
         shell: true,
       });
+    } else {
+      throw error;
     }
   }
 }


### PR DESCRIPTION
In current implementation, errors caused by running Prettier may be ignored.