### PR TITLE
Make keywords case-insensitive: vs, VS, Vs...

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -160,7 +160,7 @@ type Token =
 export function tokenize(source: string): Token[] {
   const tokens: Token[] = [];
   for (const word of source.trim().split(" ").filter(Boolean)) {
-    switch (word) {
+    switch (word.toLowerCase()) {
       case "run":
         tokens.push({ kind: "run" });
         break;


### PR DESCRIPTION
For a while, I couldn't understand what's wrong with my command `run prettier/prettier#10712 VS prettier/prettier@main` :)