### PR TITLE
Fix for "fatal: 'next' matched multiple (3) remote tracking branches"

### DIFF
--- a/src/tools/git.ts
+++ b/src/tools/git.ts
@@ -8,6 +8,7 @@ export async function remoteAdd(
   cwd: string
 ): Promise<void> {
   await execa("git", ["remote", "add", remoteName, repositoryUrl], { cwd });
+  await execa("git", ["config", "checkout.defaultRemote", remoteName], { cwd });
 }
 
 export async function fetch(remoteName: string, cwd: string): Promise<void> {


### PR DESCRIPTION
You can see these errors in https://github.com/prettier/prettier-regression-testing/issues/151